### PR TITLE
Allow private browser mode to use extention

### DIFF
--- a/firefox/package.json
+++ b/firefox/package.json
@@ -5,6 +5,7 @@
   "description": "One click to close any overlay on any website.",
   "icon": "data/courtain_32.png",
   "author": "Nicolae Namolovan",
+  "permissions": {"private-browsing": true},
   "license": "MIT",
   "version": "0.1.1"
 }


### PR DESCRIPTION
Hi,
Thanks for a wonderful extension!
One day my behindtheoverlay icon disappeared in firefox, after some searching I figured out that it was because I started to use private browsing by default and each extension has to allow it.

I figured that it would be nice to allow the extension in private mode by default
